### PR TITLE
Refactor story types to AUDIO terminology

### DIFF
--- a/SwiftTranscriptionSampleApp/Helpers/Helpers.swift
+++ b/SwiftTranscriptionSampleApp/Helpers/Helpers.swift
@@ -9,13 +9,13 @@ import Foundation
 import AVFoundation
 import SwiftUI
 
-extension Story: Equatable {
-    static func == (lhs: Story, rhs: Story) -> Bool {
+extension AudioEntry: Equatable {
+    static func == (lhs: AudioEntry, rhs: AudioEntry) -> Bool {
         lhs.id == rhs.id
     }
 }
 
-extension Story: Hashable {
+extension AudioEntry: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
@@ -97,9 +97,9 @@ extension AVAudioPlayerNode {
 }
 
 extension TranscriptView {
-    
+
     func handlePlayback() {
-        guard story.url != nil else {
+        guard audioEntry.url != nil else {
             return
         }
         
@@ -114,7 +114,7 @@ extension TranscriptView {
             timer = nil
         }
     }
-    
+
     func handleRecordingButtonTap() {
         isRecording.toggle()
     }

--- a/SwiftTranscriptionSampleApp/Models/StoryModel.swift
+++ b/SwiftTranscriptionSampleApp/Models/StoryModel.swift
@@ -2,7 +2,7 @@
 See the LICENSE.txt file for this sample’s licensing information.
 
 Abstract:
-Story data model.
+AUDIO entry data model.
 */
 
 import Foundation
@@ -10,7 +10,7 @@ import AVFoundation
 import FoundationModels
 
 @Observable
-class Story: Identifiable {
+class AudioEntry: Identifiable {
     typealias StartTime = CMTime
     
     let id: UUID
@@ -35,12 +35,12 @@ class Story: Identifiable {
     }
 }
 
-extension Story {
-    static func blank() -> Story {
-        return .init(title: "New Story", text: AttributedString(""))
+extension AudioEntry {
+    static func blankAudioEntry() -> AudioEntry {
+        return .init(title: "New AUDIO", text: AttributedString(""))
     }
-    
-    func storyBrokenUpByLines() -> AttributedString {
+
+    func audioTranscriptBrokenUpByLines() -> AttributedString {
         print(String(text.characters))
         if url == nil {
             print("url was nil")

--- a/SwiftTranscriptionSampleApp/Recording and Transcription/Recorder.swift
+++ b/SwiftTranscriptionSampleApp/Recording and Transcription/Recorder.swift
@@ -15,22 +15,22 @@ class Recorder {
     private let transcriber: SpokenWordTranscriber
     var playerNode: AVAudioPlayerNode?
     
-    var story: Binding<Story>
+    var audioEntry: Binding<AudioEntry>
     
     var file: AVAudioFile?
     private let url: URL
 
-    init(transcriber: SpokenWordTranscriber, story: Binding<Story>) {
+    init(transcriber: SpokenWordTranscriber, audioEntry: Binding<AudioEntry>) {
         audioEngine = AVAudioEngine()
         self.transcriber = transcriber
-        self.story = story
+        self.audioEntry = audioEntry
         self.url = FileManager.default.temporaryDirectory
             .appending(component: UUID().uuidString)
             .appendingPathExtension(for: .wav)
     }
-    
+
     func record() async throws {
-        self.story.url.wrappedValue = url
+        self.audioEntry.url.wrappedValue = url
         guard await isAuthorized() else {
             print("user denied mic permission")
             return
@@ -47,12 +47,12 @@ class Recorder {
     
     func stopRecording() async throws {
         audioEngine.stop()
-        story.isDone.wrappedValue = true
+        audioEntry.isDone.wrappedValue = true
 
         try await transcriber.finishTranscribing()
 
         Task {
-            self.story.title.wrappedValue = try await story.wrappedValue.suggestedTitle() ?? story.title.wrappedValue
+            self.audioEntry.title.wrappedValue = try await audioEntry.wrappedValue.suggestedTitle() ?? audioEntry.title.wrappedValue
         }
 
     }

--- a/SwiftTranscriptionSampleApp/Recording and Transcription/Transcription.swift
+++ b/SwiftTranscriptionSampleApp/Recording and Transcription/Transcription.swift
@@ -25,15 +25,15 @@ final class SpokenWordTranscriber {
     var converter = BufferConverter()
     var downloadProgress: Progress?
     
-    var story: Binding<Story>
+    var audioEntry: Binding<AudioEntry>
     
     var volatileTranscript: AttributedString = ""
     var finalizedTranscript: AttributedString = ""
     
     static let locale = Locale(components: .init(languageCode: .english, script: nil, languageRegion: .unitedStates))
     
-    init(story: Binding<Story>) {
-        self.story = story
+    init(audioEntry: Binding<AudioEntry>) {
+        self.audioEntry = audioEntry
     }
     
     func setUpTranscriber() async throws {
@@ -67,7 +67,7 @@ final class SpokenWordTranscriber {
                     if result.isFinal {
                         finalizedTranscript += text
                         volatileTranscript = ""
-                        updateStoryWithNewText(withFinal: text)
+                        updateAudioEntryWithNewText(withFinal: text)
                     } else {
                         volatileTranscript = text
                         volatileTranscript.foregroundColor = .purple.opacity(0.4)
@@ -81,8 +81,8 @@ final class SpokenWordTranscriber {
         try await analyzer?.start(inputSequence: inputSequence)
     }
     
-    func updateStoryWithNewText(withFinal str: AttributedString) {
-        story.text.wrappedValue.append(str)
+    func updateAudioEntryWithNewText(withFinal str: AttributedString) {
+        audioEntry.text.wrappedValue.append(str)
     }
     
     func streamAudioToTranscriber(_ buffer: AVAudioPCMBuffer) async throws {

--- a/SwiftTranscriptionSampleApp/Views/ContentView.swift
+++ b/SwiftTranscriptionSampleApp/Views/ContentView.swift
@@ -10,41 +10,41 @@ import SwiftData
 import Speech
 
 struct ContentView: View {
-    @State var selection: Story?
-    @State var currentStory: Story = Story.blank()
+    @State var selectedAudioEntry: AudioEntry?
+    @State var activeAudioEntry: AudioEntry = AudioEntry.blankAudioEntry()
     
     var body: some View {
         NavigationSplitView {
-            List(stories, selection: $selection) { story in
-                NavigationLink(value: story) {
-                    Text(story.title)
+            List(audioEntries, selection: $selectedAudioEntry) { audioEntry in
+                NavigationLink(value: audioEntry) {
+                    Text(audioEntry.title)
                 }
             }
-            
-            .navigationTitle("Stories")
-            
+
+            .navigationTitle("AUDIO Sessions")
+
             .toolbar {
                 ToolbarItem {
                     Button {
-                        stories.append(Story.blank())
+                        audioEntries.append(AudioEntry.blankAudioEntry())
                     } label: {
-                        Label("Add Item", systemImage: "plus")
+                        Label("New AUDIO", systemImage: "plus")
                     }
                 }
             }
         } detail: {
-            if selection != nil {
-                TranscriptView(story: $currentStory)
+            if selectedAudioEntry != nil {
+                TranscriptView(audioEntry: $activeAudioEntry)
             } else {
                 Text("Select an item")
             }
         }
-        .onChange(of: selection) {
-            if let selection {
-                currentStory = selection
+        .onChange(of: selectedAudioEntry) {
+            if let selectedAudioEntry {
+                activeAudioEntry = selectedAudioEntry
             }
         }
     }
-    
-    @State var stories: [Story] = []
+
+    @State var audioEntries: [AudioEntry] = []
 }

--- a/SwiftTranscriptionSampleApp/Views/TranscriptView.swift
+++ b/SwiftTranscriptionSampleApp/Views/TranscriptView.swift
@@ -11,10 +11,10 @@ import Speech
 import AVFoundation
 
 struct TranscriptView: View {
-    @Binding var story: Story
+    @Binding var audioEntry: AudioEntry
     @State var isRecording = false
     @State var isPlaying = false
-    
+
     @State var recorder: Recorder
     @State var speechTranscriber: SpokenWordTranscriber
     
@@ -24,17 +24,17 @@ struct TranscriptView: View {
     
     @State var timer: Timer?
     
-    init(story: Binding<Story>) {
-        self._story = story
-        let transcriber = SpokenWordTranscriber(story: story)
-        recorder = Recorder(transcriber: transcriber, story: story)
+    init(audioEntry: Binding<AudioEntry>) {
+        self._audioEntry = audioEntry
+        let transcriber = SpokenWordTranscriber(audioEntry: audioEntry)
+        recorder = Recorder(transcriber: transcriber, audioEntry: audioEntry)
         speechTranscriber = transcriber
     }
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             Group {
-                if !story.isDone {
+                if !audioEntry.isDone {
                     liveRecordingView
                 } else {
                     playbackView
@@ -43,7 +43,7 @@ struct TranscriptView: View {
             Spacer()
         }
         .padding(20)
-        .navigationTitle(story.title)
+        .navigationTitle(audioEntry.title)
         .toolbar {
             ToolbarItem {
                 Button {
@@ -55,18 +55,18 @@ struct TranscriptView: View {
                         Label("Record", systemImage: "record.circle").tint(.red)
                     }
                 }
-                .disabled(story.isDone)
+                .disabled(audioEntry.isDone)
             }
-            
+
             ToolbarItem {
                 Button {
                     handlePlayButtonTap()
                 } label: {
                     Label("Play", systemImage: isPlaying ? "pause.fill" : "play").foregroundStyle(.blue).font(.title)
                 }
-                .disabled(!story.isDone)
+                .disabled(!audioEntry.isDone)
             }
-            
+
             ToolbarItem {
                 ProgressView(value: downloadProgress, total: 100)
             }
@@ -92,7 +92,7 @@ struct TranscriptView: View {
             handlePlayback()
         }
     }
-    
+
     @ViewBuilder
     var liveRecordingView: some View {
         Text(speechTranscriber.finalizedTranscript + speechTranscriber.volatileTranscript)
@@ -102,7 +102,7 @@ struct TranscriptView: View {
     
     @ViewBuilder
     var playbackView: some View {
-        textScrollView(attributedString: story.storyBrokenUpByLines())
+        textScrollView(attributedString: audioEntry.audioTranscriptBrokenUpByLines())
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }


### PR DESCRIPTION
## Summary
- rename the story data model to AudioEntry with matching helper methods
- update recorder, transcriber, and views to adopt the new AUDIO bindings and labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e429fe0cbc832096f8f06c0f4b8117