### PR TITLE
Refactor recordings list with persistence and playback controls

### DIFF
--- a/SwiftTranscriptionSampleApp/Models/RecordingsViewModel.swift
+++ b/SwiftTranscriptionSampleApp/Models/RecordingsViewModel.swift
@@ -1,0 +1,117 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class RecordingsViewModel: ObservableObject {
+    @Published private(set) var stories: [Story] = []
+    @Published var activeSheet: Story?
+
+    private let persistence: StoryPersistence
+    private var playbackRecorder: Recorder?
+    private var playbackTranscriber: SpokenWordTranscriber?
+    private(set) var currentlyPlayingStoryID: UUID?
+
+    init(persistence: StoryPersistence = StoryPersistence()) {
+        self.persistence = persistence
+        loadPersistedStories()
+    }
+
+    func loadPersistedStories() {
+        stories = persistence.load().sorted(by: { $0.createdAt > $1.createdAt })
+    }
+
+    func createStory() -> Story {
+        let story = Story.blank()
+        story.createdAt = Date()
+        stories.insert(story, at: 0)
+        persistence.save(stories)
+        activeSheet = story
+        return story
+    }
+
+    func binding(for story: Story) -> Binding<Story>? {
+        guard let index = stories.firstIndex(where: { $0.id == story.id }) else { return nil }
+        return Binding(get: { self.stories[index] }, set: { newValue in
+            self.stories[index] = newValue
+            self.persistence.save(self.stories)
+        })
+    }
+
+    func persist(_ story: Story) {
+        guard let index = stories.firstIndex(where: { $0.id == story.id }) else { return }
+
+        objectWillChange.send()
+
+        if story.url != nil {
+            persistence.persistAudio(for: story)
+            story.isOffloaded = false
+        }
+
+        stories[index] = story
+        stories.sort(by: { $0.createdAt > $1.createdAt })
+        persistence.save(stories)
+    }
+
+    func delete(_ story: Story) {
+        guard let index = stories.firstIndex(where: { $0.id == story.id }) else { return }
+
+        stopPlayback()
+        persistence.deleteAudio(for: story)
+        stories.remove(at: index)
+        if activeSheet?.id == story.id {
+            activeSheet = nil
+        }
+        persistence.save(stories)
+    }
+
+    func offload(_ story: Story) {
+        guard let index = stories.firstIndex(where: { $0.id == story.id }) else { return }
+
+        stopPlayback()
+        persistence.deleteAudio(for: story)
+        objectWillChange.send()
+        stories[index].url = nil
+        stories[index].isOffloaded = true
+        persistence.save(stories)
+    }
+
+    func togglePlayback(for story: Story) {
+        if currentlyPlayingStoryID == story.id {
+            stopPlayback()
+        } else {
+            startPlayback(for: story)
+        }
+    }
+
+    private func startPlayback(for story: Story) {
+        guard let url = story.url, FileManager.default.fileExists(atPath: url.path) else { return }
+
+        stopPlayback()
+
+        guard let binding = binding(for: story) else { return }
+        let transcriber = SpokenWordTranscriber(story: binding)
+        let recorder = Recorder(transcriber: transcriber, story: binding)
+        recorder.prepareForPlayback(with: url)
+        recorder.playRecording()
+
+        objectWillChange.send()
+        story.isPlaying = true
+        playbackRecorder = recorder
+        playbackTranscriber = transcriber
+        currentlyPlayingStoryID = story.id
+    }
+
+    func stopPlayback() {
+        playbackRecorder?.stopPlaying()
+        playbackRecorder = nil
+        playbackTranscriber = nil
+
+        if let id = currentlyPlayingStoryID,
+           let index = stories.firstIndex(where: { $0.id == id }) {
+            objectWillChange.send()
+            stories[index].isPlaying = false
+        }
+
+        currentlyPlayingStoryID = nil
+    }
+}

--- a/SwiftTranscriptionSampleApp/Models/StoryModel.swift
+++ b/SwiftTranscriptionSampleApp/Models/StoryModel.swift
@@ -12,19 +12,30 @@ import FoundationModels
 @Observable
 class Story: Identifiable {
     typealias StartTime = CMTime
-    
+
     let id: UUID
     var title: String
     var text: AttributedString
     var url: URL?
     var isDone: Bool
-    
-    init(title: String, text: AttributedString, url: URL? = nil, isDone: Bool = false) {
+    var createdAt: Date
+    var isOffloaded: Bool
+    var isPlaying: Bool = false
+
+    init(id: UUID = UUID(),
+         title: String,
+         text: AttributedString,
+         url: URL? = nil,
+         isDone: Bool = false,
+         createdAt: Date = Date(),
+         isOffloaded: Bool = false) {
+        self.id = id
         self.title = title
         self.text = text
         self.url = url
         self.isDone = isDone
-        self.id = UUID()
+        self.createdAt = createdAt
+        self.isOffloaded = isOffloaded
     }
     
     func suggestedTitle() async throws -> String? {
@@ -37,7 +48,7 @@ class Story: Identifiable {
 
 extension Story {
     static func blank() -> Story {
-        return .init(title: "New Story", text: AttributedString(""))
+        return .init(title: "New Story", text: AttributedString(""), createdAt: Date())
     }
     
     func storyBrokenUpByLines() -> AttributedString {
@@ -74,5 +85,83 @@ extension Story {
             
             return final
         }
+    }
+}
+
+// MARK: - Persistence
+
+extension Story: Codable {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case textData
+        case url
+        case isDone
+        case createdAt
+        case isOffloaded
+    }
+
+    convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let id = try container.decode(UUID.self, forKey: .id)
+        let title = try container.decode(String.self, forKey: .title)
+        let textData = try container.decode(Data.self, forKey: .textData)
+        let nsAttributed = try NSKeyedUnarchiver.unarchivedObject(ofClass: NSAttributedString.self, from: textData) ?? NSAttributedString()
+        let text = AttributedString(nsAttributed)
+        let url = try container.decodeIfPresent(URL.self, forKey: .url)
+        let isDone = try container.decode(Bool.self, forKey: .isDone)
+        let createdAt = try container.decode(Date.self, forKey: .createdAt)
+        let isOffloaded = try container.decode(Bool.self, forKey: .isOffloaded)
+
+        self.init(id: id,
+                  title: title,
+                  text: text,
+                  url: url,
+                  isDone: isDone,
+                  createdAt: createdAt,
+                  isOffloaded: isOffloaded)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        let nsAttributed = NSAttributedString(text)
+        let data = try NSKeyedArchiver.archivedData(withRootObject: nsAttributed, requiringSecureCoding: true)
+        try container.encode(data, forKey: .textData)
+        try container.encodeIfPresent(url, forKey: .url)
+        try container.encode(isDone, forKey: .isDone)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(isOffloaded, forKey: .isOffloaded)
+    }
+}
+
+extension Story {
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    var fileSizeDescription: String {
+        guard let url, FileManager.default.fileExists(atPath: url.path) else {
+            return isOffloaded ? "Offloaded" : "--"
+        }
+
+        do {
+            let resources = try url.resourceValues(forKeys: [.fileSizeKey])
+            guard let size = resources.fileSize else { return "--" }
+            let formatter = ByteCountFormatter()
+            formatter.allowedUnits = [.useKB, .useMB]
+            formatter.countStyle = .file
+            return formatter.string(fromByteCount: Int64(size))
+        } catch {
+            return "--"
+        }
+    }
+
+    var formattedTimestamp: String {
+        Story.timestampFormatter.string(from: createdAt)
     }
 }

--- a/SwiftTranscriptionSampleApp/Models/StoryPersistence.swift
+++ b/SwiftTranscriptionSampleApp/Models/StoryPersistence.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+struct StoryPersistence {
+    private enum Constants {
+        static let storeFileName = "recordings.json"
+        static let recordingsDirectoryName = "Recordings"
+    }
+
+    private let storeURL: URL
+    private let recordingsDirectoryURL: URL
+
+    init(fileManager: FileManager = .default) {
+        let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? fileManager.temporaryDirectory
+        self.recordingsDirectoryURL = documentsDirectory.appendingPathComponent(Constants.recordingsDirectoryName, isDirectory: true)
+        self.storeURL = documentsDirectory.appendingPathComponent(Constants.storeFileName)
+
+        if !fileManager.fileExists(atPath: recordingsDirectoryURL.path) {
+            try? fileManager.createDirectory(at: recordingsDirectoryURL, withIntermediateDirectories: true)
+        }
+    }
+
+    func load() -> [Story] {
+        guard let data = try? Data(contentsOf: storeURL) else { return [] }
+
+        do {
+            let persisted = try JSONDecoder().decode([PersistedStory].self, from: data)
+            return persisted.compactMap { $0.makeStory(baseDirectory: recordingsDirectoryURL) }
+        } catch {
+            print("Failed to load recordings: \(error)")
+            return []
+        }
+    }
+
+    func save(_ stories: [Story]) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+
+        let persisted = stories.map { PersistedStory(story: $0, baseDirectory: recordingsDirectoryURL) }
+
+        do {
+            let data = try encoder.encode(persisted)
+            try data.write(to: storeURL, options: .atomic)
+        } catch {
+            print("Failed to persist recordings: \(error)")
+        }
+    }
+
+    func persistAudio(for story: Story) {
+        guard let url = story.url else { return }
+        let destination = audioURL(for: story.id)
+        let fileManager = FileManager.default
+
+        do {
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            if url != destination {
+                try fileManager.moveItem(at: url, to: destination)
+                story.url = destination
+            }
+        } catch {
+            print("Failed to persist audio file: \(error)")
+        }
+    }
+
+    func deleteAudio(for story: Story) {
+        guard let url = story.url else { return }
+        do {
+            if FileManager.default.fileExists(atPath: url.path) {
+                try FileManager.default.removeItem(at: url)
+            }
+        } catch {
+            print("Failed to delete audio file: \(error)")
+        }
+    }
+
+    func audioURL(for id: UUID) -> URL {
+        recordingsDirectoryURL.appendingPathComponent("\(id.uuidString).wav")
+    }
+}
+
+private struct PersistedStory: Codable {
+    var id: UUID
+    var title: String
+    var textData: Data
+    var audioFileName: String?
+    var isDone: Bool
+    var createdAt: Date
+    var isOffloaded: Bool
+
+    init(story: Story, baseDirectory: URL) {
+        self.id = story.id
+        self.title = story.title
+        let nsAttributed = NSAttributedString(story.text)
+        self.textData = (try? NSKeyedArchiver.archivedData(withRootObject: nsAttributed, requiringSecureCoding: true)) ?? Data()
+        self.audioFileName = story.url?.lastPathComponent
+        self.isDone = story.isDone
+        self.createdAt = story.createdAt
+        self.isOffloaded = story.isOffloaded
+    }
+
+    func makeStory(baseDirectory: URL) -> Story? {
+        guard let nsAttributed = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSAttributedString.self, from: textData) else { return nil }
+        let story = Story(id: id,
+                          title: title,
+                          text: AttributedString(nsAttributed),
+                          url: audioFileName.map { baseDirectory.appendingPathComponent($0) },
+                          isDone: isDone,
+                          createdAt: createdAt,
+                          isOffloaded: isOffloaded)
+        return story
+    }
+}

--- a/SwiftTranscriptionSampleApp/Views/ContentView.swift
+++ b/SwiftTranscriptionSampleApp/Views/ContentView.swift
@@ -6,45 +6,35 @@ The app's main view.
 */
 
 import SwiftUI
-import SwiftData
-import Speech
 
 struct ContentView: View {
-    @State var selection: Story?
-    @State var currentStory: Story = Story.blank()
-    
+    @StateObject private var viewModel = RecordingsViewModel()
+
     var body: some View {
-        NavigationSplitView {
-            List(stories, selection: $selection) { story in
-                NavigationLink(value: story) {
-                    Text(story.title)
-                }
-            }
-            
-            .navigationTitle("Stories")
-            
-            .toolbar {
-                ToolbarItem {
-                    Button {
-                        stories.append(Story.blank())
-                    } label: {
-                        Label("Add Item", systemImage: "plus")
+        NavigationStack {
+            RecordingListView(viewModel: viewModel)
+                .navigationTitle("Recordings")
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button {
+                            _ = viewModel.createStory()
+                        } label: {
+                            Label("New Recording", systemImage: "plus")
+                        }
                     }
                 }
-            }
-        } detail: {
-            if selection != nil {
-                TranscriptView(story: $currentStory)
-            } else {
-                Text("Select an item")
-            }
         }
-        .onChange(of: selection) {
-            if let selection {
-                currentStory = selection
+        .environmentObject(viewModel)
+        .sheet(item: $viewModel.activeSheet) { story in
+            if let binding = viewModel.binding(for: story) {
+                NavigationStack {
+                    TranscriptView(story: binding)
+                }
+                .environmentObject(viewModel)
+            } else {
+                Text("Recording unavailable")
+                    .padding()
             }
         }
     }
-    
-    @State var stories: [Story] = []
 }

--- a/SwiftTranscriptionSampleApp/Views/RecordingListView.swift
+++ b/SwiftTranscriptionSampleApp/Views/RecordingListView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct RecordingListView: View {
+    @ObservedObject var viewModel: RecordingsViewModel
+
+    var body: some View {
+        List {
+            if viewModel.stories.isEmpty {
+                ContentUnavailableView("No Recordings",
+                                        systemImage: "waveform",
+                                        description: Text("Start a new session to capture audio and transcripts."))
+            }
+
+            ForEach(viewModel.stories) { story in
+                RecordingRow(story: story) {
+                    viewModel.togglePlayback(for: story)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    viewModel.activeSheet = story
+                }
+                .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                    Button(role: .destructive) {
+                        viewModel.delete(story)
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button {
+                        viewModel.offload(story)
+                    } label: {
+                        Label("Offload", systemImage: "externaldrive.badge.minus")
+                    }
+                    .tint(.indigo)
+                    .disabled(story.url == nil)
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+}

--- a/SwiftTranscriptionSampleApp/Views/RecordingRow.swift
+++ b/SwiftTranscriptionSampleApp/Views/RecordingRow.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import Observation
+
+struct RecordingRow: View {
+    @Bindable var story: Story
+    let togglePlayback: () -> Void
+
+    init(story: Story, togglePlayback: @escaping () -> Void) {
+        self._story = Bindable(story)
+        self.togglePlayback = togglePlayback
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(story.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+
+                HStack(spacing: 8) {
+                    Text(story.formattedTimestamp)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if story.isOffloaded {
+                        Label("Offloaded", systemImage: "icloud.slash")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
+            }
+
+            Spacer()
+
+            Text(story.fileSizeDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button(action: togglePlayback) {
+                Image(systemName: story.isPlaying ? "stop.fill" : "play.fill")
+                    .font(.title3)
+            }
+            .buttonStyle(.borderless)
+            .disabled(story.url == nil)
+            .accessibilityLabel(story.isPlaying ? "Stop playback" : "Play recording")
+        }
+        .padding(.vertical, 8)
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the root view to use a navigation stack with a recordings list backed by a view model
- add SwiftUI rows with playback controls and swipe actions tied to recorder management
- persist recordings and update transcript playback/offload flows with the new model

## Testing
- Not Run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e42ac5a3d48320b2072234e8999592