### PR TITLE
Add keychain-authenticated login flow for recordings dashboard

### DIFF
--- a/SwiftTranscriptionAudioApp/Helpers/KeychainStorage.swift
+++ b/SwiftTranscriptionAudioApp/Helpers/KeychainStorage.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Security
+
+enum KeychainStorageError: LocalizedError {
+    case unexpectedStatus(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .unexpectedStatus(let status):
+            if let message = SecCopyErrorMessageString(status, nil) as String? {
+                return message
+            }
+            return "Keychain operation failed with status: \(status)."
+        }
+    }
+}
+
+enum KeychainStorage {
+    static func store(_ data: Data, service: String, account: String) throws {
+        var query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account
+        ]
+
+        SecItemDelete(query as CFDictionary)
+
+        query[kSecValueData] = data
+        query[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else { throw KeychainStorageError.unexpectedStatus(status) }
+    }
+
+    static func load(service: String, account: String) throws -> Data? {
+        var query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecReturnData: kCFBooleanTrue as Any,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            return result as? Data
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainStorageError.unexpectedStatus(status)
+        }
+    }
+
+    static func delete(service: String, account: String) throws {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainStorageError.unexpectedStatus(status)
+        }
+    }
+}

--- a/SwiftTranscriptionAudioApp/Helpers/SwiftTranscriptionAudioApp.swift
+++ b/SwiftTranscriptionAudioApp/Helpers/SwiftTranscriptionAudioApp.swift
@@ -10,9 +10,33 @@ import SwiftData
 
 @main
 struct SwiftTranscriptionAudioApp: App {
+    @StateObject private var authViewModel = AuthenticationViewModel()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            Group {
+                if let session = authViewModel.session {
+                    AuthenticatedSessionView(session: session)
+                } else {
+                    LoginView()
+                }
+            }
+            .environmentObject(authViewModel)
         }
+    }
+}
+
+private struct AuthenticatedSessionView: View {
+    let session: AuthSession
+    @StateObject private var storyModel: StoryModel
+
+    init(session: AuthSession) {
+        self.session = session
+        _storyModel = StateObject(wrappedValue: StoryModel(session: session))
+    }
+
+    var body: some View {
+        ContentView(viewModel: storyModel)
+            .id(session.knowledgeBaseUserID)
     }
 }

--- a/SwiftTranscriptionAudioApp/Models/AuthSession.swift
+++ b/SwiftTranscriptionAudioApp/Models/AuthSession.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+struct AuthSession: Codable, Equatable {
+    enum ValidationError: LocalizedError {
+        case missingUserID
+        case missingAPIKey
+        case invalidBaseURL
+
+        var errorDescription: String? {
+            switch self {
+            case .missingUserID:
+                return "User ID is required."
+            case .missingAPIKey:
+                return "API Key is required."
+            case .invalidBaseURL:
+                return "Enter a valid knowledge base URL."
+            }
+        }
+    }
+
+    let knowledgeBaseBaseURLString: String
+    let knowledgeBaseAPIKey: String
+    let knowledgeBaseUserID: String
+    let megaEmail: String?
+    let megaPassword: String?
+
+    static let keychainService = "com.apple.swifttranscription.session"
+    static let keychainAccount = "AuthenticatedUserSession"
+
+    var knowledgeBaseBaseURL: URL? {
+        URL(string: knowledgeBaseBaseURLString)
+    }
+
+    static func make(userID: String,
+                     apiKey: String,
+                     baseURL: String,
+                     megaEmail: String?,
+                     megaPassword: String?) throws -> AuthSession {
+        let trimmedUserID = userID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedUserID.isEmpty else { throw ValidationError.missingUserID }
+
+        let trimmedAPIKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedAPIKey.isEmpty else { throw ValidationError.missingAPIKey }
+
+        let trimmedBaseURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let normalizedURL = URL(string: trimmedBaseURL),
+              !normalizedURL.absoluteString.isEmpty,
+              normalizedURL.scheme != nil else { throw ValidationError.invalidBaseURL }
+
+        var sanitizedMegaEmail = megaEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if sanitizedMegaEmail?.isEmpty ?? true {
+            sanitizedMegaEmail = nil
+        }
+
+        var sanitizedMegaPassword = megaPassword?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if sanitizedMegaPassword?.isEmpty ?? true {
+            sanitizedMegaPassword = nil
+        }
+
+        if (sanitizedMegaEmail == nil) != (sanitizedMegaPassword == nil) {
+            sanitizedMegaEmail = nil
+            sanitizedMegaPassword = nil
+        }
+
+        return AuthSession(knowledgeBaseBaseURLString: normalizedURL.absoluteString,
+                           knowledgeBaseAPIKey: trimmedAPIKey,
+                           knowledgeBaseUserID: trimmedUserID,
+                           megaEmail: sanitizedMegaEmail,
+                           megaPassword: sanitizedMegaPassword)
+    }
+}

--- a/SwiftTranscriptionAudioApp/Models/AuthenticationViewModel.swift
+++ b/SwiftTranscriptionAudioApp/Models/AuthenticationViewModel.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+@MainActor
+final class AuthenticationViewModel: ObservableObject {
+    @Published private(set) var session: AuthSession?
+    @Published var isProcessing = false
+    @Published var errorMessage: String?
+
+    init() {
+        session = AuthenticationViewModel.loadSessionFromKeychain()
+    }
+
+    func login(userID: String,
+               apiKey: String,
+               baseURL: String,
+               megaEmail: String?,
+               megaPassword: String?) async {
+        errorMessage = nil
+        isProcessing = true
+        defer { isProcessing = false }
+
+        do {
+            let newSession = try AuthSession.make(userID: userID,
+                                                  apiKey: apiKey,
+                                                  baseURL: baseURL,
+                                                  megaEmail: megaEmail,
+                                                  megaPassword: megaPassword)
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(newSession)
+            try KeychainStorage.store(data,
+                                      service: AuthSession.keychainService,
+                                      account: AuthSession.keychainAccount)
+            session = newSession
+        } catch {
+            if let error = error as? LocalizedError {
+                errorMessage = error.errorDescription
+            } else {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func logout(currentStoryModel: StoryModel?) {
+        currentStoryModel?.reset()
+        try? KeychainStorage.delete(service: AuthSession.keychainService,
+                                    account: AuthSession.keychainAccount)
+        session = nil
+    }
+
+    func defaultKnowledgeBaseURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        if let url = environment["KB_API_BASE_URL"] ?? environment["KBAgentBaseURL"], !url.isEmpty {
+            return url
+        }
+        return "https://"
+    }
+
+    private static func loadSessionFromKeychain() -> AuthSession? {
+        guard let data = try? KeychainStorage.load(service: AuthSession.keychainService,
+                                                   account: AuthSession.keychainAccount) else {
+            return nil
+        }
+
+        guard let data else { return nil }
+        return try? JSONDecoder().decode(AuthSession.self, from: data)
+    }
+}

--- a/SwiftTranscriptionAudioApp/Models/RecordingStore.swift
+++ b/SwiftTranscriptionAudioApp/Models/RecordingStore.swift
@@ -71,6 +71,26 @@ struct RecordingStore {
         RecordingStore.audioURL(for: id, fileManager: fileManager)
     }
 
+    func reset() {
+        do {
+            if fileManager.fileExists(atPath: storeURL.path) {
+                try fileManager.removeItem(at: storeURL)
+            }
+        } catch {
+            print("Failed to clear recordings store: \(error)")
+        }
+
+        let directory = RecordingStore.recordingsDirectory(fileManager: fileManager)
+        if fileManager.fileExists(atPath: directory.path) {
+            do {
+                try fileManager.removeItem(at: directory)
+            } catch {
+                print("Failed to remove recordings directory: \(error)")
+            }
+            try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+    }
+
     private static func baseDirectory(fileManager: FileManager = .default) -> URL {
         #if os(macOS)
         if let applicationSupport = try? fileManager.url(for: .applicationSupportDirectory,

--- a/SwiftTranscriptionAudioApp/Services/MegaStorageService.swift
+++ b/SwiftTranscriptionAudioApp/Services/MegaStorageService.swift
@@ -43,6 +43,22 @@ final class MegaStorageService: NSObject {
                       password: password,
                       parentHandle: parentHandle)
         }
+
+        init?(bundle: Bundle = .main, email: String, password: String) {
+            guard let appKey = bundle.object(forInfoDictionaryKey: "MEGAAppKey") as? String,
+                  let userAgent = bundle.object(forInfoDictionaryKey: "MEGAUserAgent") as? String else {
+                return nil
+            }
+
+            let parentHandleString = bundle.object(forInfoDictionaryKey: "MEGAParentHandle") as? String
+            let parentHandle = parentHandleString.flatMap { UInt64($0) }
+
+            self.init(appKey: appKey,
+                      userAgent: userAgent,
+                      email: email,
+                      password: password,
+                      parentHandle: parentHandle)
+        }
     }
 
     struct UploadResult {

--- a/SwiftTranscriptionAudioApp/Views/ContentView.swift
+++ b/SwiftTranscriptionAudioApp/Views/ContentView.swift
@@ -8,30 +8,47 @@ The app's main view.
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject private var storyModel = StoryModel()
+    @ObservedObject var viewModel: StoryModel
+    @EnvironmentObject private var authViewModel: AuthenticationViewModel
 
     var body: some View {
         NavigationStack {
-            RecordingListView(viewModel: storyModel)
+            RecordingListView(viewModel: viewModel)
                 .navigationTitle("Recordings")
                 .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Log Out", role: .destructive, action: logout)
+                    }
+
+                    if let userID = viewModel.authenticatedUserID {
+                        ToolbarItem(placement: .secondaryAction) {
+                            Text("Signed in as \(userID)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
                     ToolbarItem(placement: .primaryAction) {
                         Button {
-                            let recording = storyModel.createRecording()
-                            storyModel.activeRecording = recording
+                            let recording = viewModel.createRecording()
+                            viewModel.activeRecording = recording
                         } label: {
                             Label("New Recording", systemImage: "plus")
                         }
                     }
                 }
         }
-        .sheet(item: $storyModel.activeRecording) { recording in
-            if let binding = storyModel.binding(for: recording) {
-                TranscriptView(recording: binding, storyModel: storyModel)
+        .sheet(item: $viewModel.activeRecording) { recording in
+            if let binding = viewModel.binding(for: recording) {
+                TranscriptView(recording: binding, storyModel: viewModel)
             } else {
                 Text("Unable to load recording")
                     .padding()
             }
         }
+    }
+
+    private func logout() {
+        authViewModel.logout(currentStoryModel: viewModel)
     }
 }

--- a/SwiftTranscriptionAudioApp/Views/LoginView.swift
+++ b/SwiftTranscriptionAudioApp/Views/LoginView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject private var authViewModel: AuthenticationViewModel
+    @State private var knowledgeBaseURL: String = ""
+    @State private var knowledgeBaseAPIKey: String = ""
+    @State private var knowledgeBaseUserID: String = ""
+    @State private var useMegaStorage = false
+    @State private var megaEmail: String = ""
+    @State private var megaPassword: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Knowledge Base"),
+                        footer: Text("Provide the API credentials that allow transcripts to sync to your knowledge base.")) {
+                    TextField("Base URL", text: $knowledgeBaseURL)
+                        .keyboardType(.URL)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    SecureField("API Key", text: $knowledgeBaseAPIKey)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+
+                    TextField("User ID", text: $knowledgeBaseUserID)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+
+                Section(header: Toggle(isOn: $useMegaStorage.animation()) {
+                    Text("Use MEGA for remote storage")
+                }) {
+                    if useMegaStorage {
+                        TextField("MEGA Email", text: $megaEmail)
+                            .keyboardType(.emailAddress)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+
+                        SecureField("MEGA Password", text: $megaPassword)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                    } else {
+                        Text("Audio files remain on-device when MEGA is disabled.")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let errorMessage = authViewModel.errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Sign In")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: signIn) {
+                        if authViewModel.isProcessing {
+                            ProgressView()
+                        } else {
+                            Text("Continue")
+                        }
+                    }
+                    .disabled(authViewModel.isProcessing)
+                }
+            }
+        }
+        .onAppear {
+            if knowledgeBaseURL.isEmpty {
+                knowledgeBaseURL = authViewModel.defaultKnowledgeBaseURL()
+            }
+        }
+    }
+
+    private func signIn() {
+        Task {
+            await authViewModel.login(userID: knowledgeBaseUserID,
+                                      apiKey: knowledgeBaseAPIKey,
+                                      baseURL: knowledgeBaseURL,
+                                      megaEmail: useMegaStorage ? megaEmail : nil,
+                                      megaPassword: useMegaStorage ? megaPassword : nil)
+        }
+    }
+}
+
+#Preview {
+    LoginView()
+        .environmentObject(AuthenticationViewModel())
+}


### PR DESCRIPTION
## Summary
- add a keychain-backed authentication flow with a login form for knowledge base and optional MEGA credentials
- store authenticated session details in a shared view model and inject them into StoryModel, knowledge base, and MEGA services
- gate the recordings UI behind the new login scene and ensure logout clears cached recordings

## Testing
- not run (iOS build requires Xcode, unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e43df129cc8320a12ef215fd0a587b