### PR TITLE
Refactor login form and recording file coordination

### DIFF
--- a/SwiftTranscriptionAudioApp/Models/AuthSession.swift
+++ b/SwiftTranscriptionAudioApp/Models/AuthSession.swift
@@ -68,4 +68,14 @@ struct AuthSession: Codable, Equatable {
                            megaEmail: sanitizedMegaEmail,
                            megaPassword: sanitizedMegaPassword)
     }
+
+    static func make(from credentials: LoginCredentials) throws -> AuthSession {
+        let kb = credentials.knowledgeBase
+        let mega = credentials.mega
+        return try make(userID: kb.userID,
+                        apiKey: kb.apiKey,
+                        baseURL: kb.baseURL,
+                        megaEmail: mega.email,
+                        megaPassword: mega.password)
+    }
 }

--- a/SwiftTranscriptionAudioApp/Models/AuthenticationViewModel.swift
+++ b/SwiftTranscriptionAudioApp/Models/AuthenticationViewModel.swift
@@ -10,21 +10,13 @@ final class AuthenticationViewModel: ObservableObject {
         session = AuthenticationViewModel.loadSessionFromKeychain()
     }
 
-    func login(userID: String,
-               apiKey: String,
-               baseURL: String,
-               megaEmail: String?,
-               megaPassword: String?) async {
+    func login(with credentials: LoginCredentials) async {
         errorMessage = nil
         isProcessing = true
         defer { isProcessing = false }
 
         do {
-            let newSession = try AuthSession.make(userID: userID,
-                                                  apiKey: apiKey,
-                                                  baseURL: baseURL,
-                                                  megaEmail: megaEmail,
-                                                  megaPassword: megaPassword)
+            let newSession = try AuthSession.make(from: credentials)
             let encoder = JSONEncoder()
             let data = try encoder.encode(newSession)
             try KeychainStorage.store(data,

--- a/SwiftTranscriptionAudioApp/Models/LoginCredentials.swift
+++ b/SwiftTranscriptionAudioApp/Models/LoginCredentials.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+struct LoginCredentials {
+    struct KnowledgeBase {
+        let baseURL: String
+        let apiKey: String
+        let userID: String
+    }
+
+    struct Mega {
+        let email: String?
+        let password: String?
+
+        var isConfigured: Bool {
+            email != nil && password != nil
+        }
+    }
+
+    let knowledgeBase: KnowledgeBase
+    let mega: Mega
+
+    init(knowledgeBaseURL: String,
+         apiKey: String,
+         userID: String,
+         megaEmail: String?,
+         megaPassword: String?) {
+        let trimmedURL = knowledgeBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedAPIKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedUserID = userID.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let sanitizedEmail = megaEmail?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        let sanitizedPassword = megaPassword?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+
+        let megaCredentials: Mega
+        if sanitizedEmail == nil || sanitizedPassword == nil {
+            megaCredentials = Mega(email: nil, password: nil)
+        } else {
+            megaCredentials = Mega(email: sanitizedEmail, password: sanitizedPassword)
+        }
+
+        self.knowledgeBase = KnowledgeBase(baseURL: trimmedURL,
+                                           apiKey: trimmedAPIKey,
+                                           userID: trimmedUserID)
+        self.mega = megaCredentials
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/SwiftTranscriptionAudioApp/Models/RecordingStore.swift
+++ b/SwiftTranscriptionAudioApp/Models/RecordingStore.swift
@@ -1,27 +1,15 @@
 import Foundation
 
 struct RecordingStore {
-    private enum Constants {
-        static let storeFileName = "recordings.json"
-        static let recordingsDirectoryName = "Recordings"
-    }
+    private let fileCoordinator: RecordingFileCoordinator
 
-    private let fileManager: FileManager
-    private let storeURL: URL
-
-    init(fileManager: FileManager = .default) {
-        self.fileManager = fileManager
-        let baseDirectory = RecordingStore.baseDirectory(fileManager: fileManager)
-        self.storeURL = baseDirectory.appendingPathComponent(Constants.storeFileName)
-
-        let recordingsDirectory = RecordingStore.recordingsDirectory(fileManager: fileManager)
-        if !fileManager.fileExists(atPath: recordingsDirectory.path) {
-            try? fileManager.createDirectory(at: recordingsDirectory, withIntermediateDirectories: true)
-        }
+    init(fileManager: FileManager = .default,
+         fileCoordinator: RecordingFileCoordinator? = nil) {
+        self.fileCoordinator = fileCoordinator ?? RecordingFileCoordinator(fileManager: fileManager)
     }
 
     func load() -> [Recording] {
-        guard let data = try? Data(contentsOf: storeURL) else { return [] }
+        guard let data = try? Data(contentsOf: fileCoordinator.storeURL) else { return [] }
 
         do {
             let decoder = JSONDecoder()
@@ -41,7 +29,7 @@ struct RecordingStore {
 
         do {
             let data = try encoder.encode(recordings)
-            try data.write(to: storeURL, options: .atomic)
+            try data.write(to: fileCoordinator.storeURL, options: .atomic)
         } catch {
             print("Failed to persist recordings: \(error)")
         }
@@ -49,62 +37,22 @@ struct RecordingStore {
 
     func deleteAudio(for recording: Recording) {
         guard let url = recording.fileURL else { return }
-        do {
-            if fileManager.fileExists(atPath: url.path) {
-                try fileManager.removeItem(at: url)
-            }
-        } catch {
-            print("Failed to delete audio file: \(error)")
-        }
+        fileCoordinator.deleteAudioIfNeeded(at: url)
     }
 
     static func recordingsDirectory(fileManager: FileManager = .default) -> URL {
-        RecordingStore.baseDirectory(fileManager: fileManager)
-            .appendingPathComponent(Constants.recordingsDirectoryName, isDirectory: true)
+        RecordingFileCoordinator(fileManager: fileManager).recordingsDirectory
     }
 
     static func audioURL(for id: UUID, fileManager: FileManager = .default) -> URL {
-        recordingsDirectory(fileManager: fileManager).appendingPathComponent("\(id.uuidString).m4a")
+        RecordingFileCoordinator(fileManager: fileManager).audioURL(for: id)
     }
 
     func destinationURL(for id: UUID) -> URL {
-        RecordingStore.audioURL(for: id, fileManager: fileManager)
+        fileCoordinator.audioURL(for: id)
     }
 
     func reset() {
-        do {
-            if fileManager.fileExists(atPath: storeURL.path) {
-                try fileManager.removeItem(at: storeURL)
-            }
-        } catch {
-            print("Failed to clear recordings store: \(error)")
-        }
-
-        let directory = RecordingStore.recordingsDirectory(fileManager: fileManager)
-        if fileManager.fileExists(atPath: directory.path) {
-            do {
-                try fileManager.removeItem(at: directory)
-            } catch {
-                print("Failed to remove recordings directory: \(error)")
-            }
-            try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        }
-    }
-
-    private static func baseDirectory(fileManager: FileManager = .default) -> URL {
-        #if os(macOS)
-        if let applicationSupport = try? fileManager.url(for: .applicationSupportDirectory,
-                                                         in: .userDomainMask,
-                                                         appropriateFor: nil,
-                                                         create: true) {
-            let bundleID = Bundle.main.bundleIdentifier ?? "SwiftTranscriptionAudioApp"
-            let directory = applicationSupport.appendingPathComponent(bundleID, isDirectory: true)
-            if !fileManager.fileExists(atPath: directory.path) {
-                try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-            }
-            return directory
-        }
-        #endif
-        return fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? fileManager.temporaryDirectory
+        fileCoordinator.reset()
     }
 }

--- a/SwiftTranscriptionAudioApp/Services/RecordingFileCoordinator.swift
+++ b/SwiftTranscriptionAudioApp/Services/RecordingFileCoordinator.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+struct RecordingFileCoordinator {
+    private enum Constants {
+        static let storeFileName = "recordings.json"
+        static let recordingsDirectoryName = "Recordings"
+    }
+
+    private let fileManager: FileManager
+
+    let baseDirectory: URL
+    let storeURL: URL
+    let recordingsDirectory: URL
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        self.baseDirectory = RecordingFileCoordinator.baseDirectory(fileManager: fileManager)
+        self.storeURL = baseDirectory.appendingPathComponent(Constants.storeFileName)
+        self.recordingsDirectory = baseDirectory.appendingPathComponent(Constants.recordingsDirectoryName,
+                                                                         isDirectory: true)
+        ensureRecordingsDirectoryExists()
+    }
+
+    func audioURL(for id: UUID) -> URL {
+        recordingsDirectory.appendingPathComponent("\(id.uuidString).m4a")
+    }
+
+    func deleteAudioIfNeeded(at url: URL) {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+
+        do {
+            try fileManager.removeItem(at: url)
+        } catch {
+            print("Failed to delete audio file: \(error)")
+        }
+    }
+
+    func reset() {
+        removeStore()
+        removeRecordingsDirectory()
+        ensureRecordingsDirectoryExists()
+    }
+
+    private func ensureRecordingsDirectoryExists() {
+        guard !fileManager.fileExists(atPath: recordingsDirectory.path) else { return }
+        do {
+            try fileManager.createDirectory(at: recordingsDirectory, withIntermediateDirectories: true)
+        } catch {
+            print("Failed to create recordings directory: \(error)")
+        }
+    }
+
+    private func removeStore() {
+        guard fileManager.fileExists(atPath: storeURL.path) else { return }
+        do {
+            try fileManager.removeItem(at: storeURL)
+        } catch {
+            print("Failed to clear recordings store: \(error)")
+        }
+    }
+
+    private func removeRecordingsDirectory() {
+        guard fileManager.fileExists(atPath: recordingsDirectory.path) else { return }
+        do {
+            try fileManager.removeItem(at: recordingsDirectory)
+        } catch {
+            print("Failed to remove recordings directory: \(error)")
+        }
+    }
+
+    private static func baseDirectory(fileManager: FileManager = .default) -> URL {
+        #if os(macOS)
+        if let applicationSupport = try? fileManager.url(for: .applicationSupportDirectory,
+                                                         in: .userDomainMask,
+                                                         appropriateFor: nil,
+                                                         create: true) {
+            let bundleID = Bundle.main.bundleIdentifier ?? "SwiftTranscriptionAudioApp"
+            let directory = applicationSupport.appendingPathComponent(bundleID, isDirectory: true)
+            if !fileManager.fileExists(atPath: directory.path) {
+                try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            }
+            return directory
+        }
+        #endif
+        return fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? fileManager.temporaryDirectory
+    }
+}


### PR DESCRIPTION
## Summary
- reorganized the login flow with a dedicated form state and reusable sections, and added credential normalization helpers
- updated authentication to consume the new credential model and provided a convenience initializer on `AuthSession`
- centralized recording file and directory handling in a new coordinator used by `RecordingStore`

## Testing
- Not run (Xcode project; `xcodebuild test` requires macOS tooling)


------
https://chatgpt.com/codex/tasks/task_e_68e44085c070832085e884af47ee6e7a