### PR TITLE
Fix optional unwrapping when loading Keychain session

### DIFF
--- a/SwiftTranscriptionAudioApp/Models/AuthenticationViewModel.swift
+++ b/SwiftTranscriptionAudioApp/Models/AuthenticationViewModel.swift
@@ -47,12 +47,12 @@ final class AuthenticationViewModel: ObservableObject {
     }
 
     private static func loadSessionFromKeychain() -> AuthSession? {
-        guard let data = try? KeychainStorage.load(service: AuthSession.keychainService,
-                                                   account: AuthSession.keychainAccount) else {
+        guard let storedData = try? KeychainStorage.load(service: AuthSession.keychainService,
+                                                         account: AuthSession.keychainAccount),
+              let data = storedData else {
             return nil
         }
 
-        guard let data else { return nil }
         return try? JSONDecoder().decode(AuthSession.self, from: data)
     }
 }


### PR DESCRIPTION
## Summary
- correctly unwrap the optional data returned from the keychain
- return nil when no data is stored, avoiding double optional binding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e451fc90688320a403d6a6c869fc04