### PR TITLE
Fix keychain session loading compilation error

### DIFF
--- a/SwiftTranscriptionAudioApp/Models/AuthenticationViewModel.swift
+++ b/SwiftTranscriptionAudioApp/Models/AuthenticationViewModel.swift
@@ -47,12 +47,15 @@ final class AuthenticationViewModel: ObservableObject {
     }
 
     private static func loadSessionFromKeychain() -> AuthSession? {
-        guard let storedData = try? KeychainStorage.load(service: AuthSession.keychainService,
-                                                         account: AuthSession.keychainAccount),
-              let data = storedData else {
+        do {
+            guard let data = try KeychainStorage.load(service: AuthSession.keychainService,
+                                                     account: AuthSession.keychainAccount) else {
+                return nil
+            }
+
+            return try JSONDecoder().decode(AuthSession.self, from: data)
+        } catch {
             return nil
         }
-
-        return try? JSONDecoder().decode(AuthSession.self, from: data)
     }
 }


### PR DESCRIPTION
## Summary
- wrap keychain session loading in a do/catch and guard
- return nil when keychain or decoding fails without using invalid optional binding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e452c5bb548320a5759f281b2a21ca