### PR TITLE
Fix StoryModel default service initialization on main actor

### DIFF
--- a/SwiftTranscriptionAudioApp/Models/StoryModel.swift
+++ b/SwiftTranscriptionAudioApp/Models/StoryModel.swift
@@ -20,11 +20,20 @@ final class StoryModel: ObservableObject {
     private(set) var currentlyPlayingRecordingID: UUID?
 
     init(store: RecordingStore = RecordingStore(),
-         megaService: MegaStorageService? = MegaStorageService.makeDefault(),
-         knowledgeBaseService: KnowledgeBaseService? = KnowledgeBaseService.makeDefault()) {
+         megaService: MegaStorageService? = nil,
+         knowledgeBaseService: KnowledgeBaseService? = nil) {
         self.store = store
-        self.megaService = megaService
-        self.knowledgeBaseService = knowledgeBaseService
+        if let megaService {
+            self.megaService = megaService
+        } else {
+            self.megaService = MegaStorageService.makeDefault()
+        }
+
+        if let knowledgeBaseService {
+            self.knowledgeBaseService = knowledgeBaseService
+        } else {
+            self.knowledgeBaseService = KnowledgeBaseService.makeDefault()
+        }
         self.authenticatedUserID = nil
         loadPersistedRecordings()
     }


### PR DESCRIPTION
## Summary
- avoid default parameter calls to main-actor isolated service factories
- lazily create MegaStorageService and KnowledgeBaseService instances inside the initializer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45704bcec8320ae0d35e232e2e17c