### PR TITLE
Fix Recording decoder initialization order

### DIFF
--- a/SwiftTranscriptionAudioApp/Models/Recording.swift
+++ b/SwiftTranscriptionAudioApp/Models/Recording.swift
@@ -118,8 +118,10 @@ final class Recording: Identifiable, Codable {
             fileURL = nil
         }
         isComplete = try container.decode(Bool.self, forKey: .isComplete)
-        createdAt = try container.decode(Date.self, forKey: .createdAt)
-        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? createdAt
+        let decodedCreatedAt = try container.decode(Date.self, forKey: .createdAt)
+        let decodedUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? decodedCreatedAt
+        createdAt = decodedCreatedAt
+        updatedAt = decodedUpdatedAt
         isOffloaded = try container.decode(Bool.self, forKey: .isOffloaded)
         megaNodeHandle = try container.decodeIfPresent(UInt64.self, forKey: .megaNodeHandle)
         duration = try container.decodeIfPresent(TimeInterval.self, forKey: .duration) ?? 0


### PR DESCRIPTION
## Summary
- decode `createdAt` and `updatedAt` into local constants before assigning stored properties
- ensure `updatedAt` always falls back to the decoded `createdAt` value without touching uninitialised storage

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e458d12a9c832097f2498cb8f7d794