### PR TITLE
Fix recorded audio playback by using CAF files

### DIFF
--- a/SwiftTranscriptionAudioApp/Recording and Transcription/Transcription.swift
+++ b/SwiftTranscriptionAudioApp/Recording and Transcription/Transcription.swift
@@ -139,7 +139,7 @@ final class SpokenWordTranscriber {
         let submission = KnowledgeBaseService.TranscriptSubmission(
             id: recording.wrappedValue.id,
             userID: nil,
-            fileName: recording.wrappedValue.fileURL?.lastPathComponent ?? "\(recording.wrappedValue.id.uuidString).m4a",
+            fileName: recording.wrappedValue.fileURL?.lastPathComponent ?? RecordingFileCoordinator.defaultAudioFileName(for: recording.wrappedValue.id),
             transcriptionText: transcriptText,
             speaker: nil,
             createdAt: recording.wrappedValue.createdAt,

--- a/SwiftTranscriptionAudioApp/Services/RecordingFileCoordinator.swift
+++ b/SwiftTranscriptionAudioApp/Services/RecordingFileCoordinator.swift
@@ -4,6 +4,7 @@ struct RecordingFileCoordinator {
     private enum Constants {
         static let storeFileName = "recordings.json"
         static let recordingsDirectoryName = "Recordings"
+        static let recordingFileExtension = "caf"
     }
 
     private let fileManager: FileManager
@@ -22,7 +23,15 @@ struct RecordingFileCoordinator {
     }
 
     func audioURL(for id: UUID) -> URL {
-        recordingsDirectory.appendingPathComponent("\(id.uuidString).m4a")
+        recordingsDirectory.appendingPathComponent(audioFileName(for: id))
+    }
+
+    static func defaultAudioFileName(for id: UUID) -> String {
+        "\(id.uuidString).\(Constants.recordingFileExtension)"
+    }
+
+    private func audioFileName(for id: UUID) -> String {
+        Self.defaultAudioFileName(for: id)
     }
 
     func deleteAudioIfNeeded(at url: URL) {


### PR DESCRIPTION
## Summary
- change recorded audio assets to use the CAF container instead of the mismatched m4a extension
- expose a helper for generating the default audio filename so fallback metadata uses the new extension

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e460a5283c8320b849d3e9da339645