### PR TITLE
Fix playback after recording

### DIFF
--- a/SwiftTranscriptionAudioApp/Recording and Transcription/Recorder.swift
+++ b/SwiftTranscriptionAudioApp/Recording and Transcription/Recorder.swift
@@ -55,6 +55,8 @@ class Recorder {
 
     func stopRecording() async throws {
         audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        file = nil
         recording.isComplete.wrappedValue = true
 
         try await transcriber.finishTranscribing()


### PR DESCRIPTION
## Summary
- clear the recording tap and reset the writer handle when stopping a recording so the saved file can be reopened for playback

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e46560f9b08320b0f623924458fb53